### PR TITLE
Add comment (mainly for render)

### DIFF
--- a/src/Data/Makefile.hs
+++ b/src/Data/Makefile.hs
@@ -32,9 +32,9 @@ Makefile {
 
 module Data.Makefile where
 
-import           Data.String                      (IsString)
+import           Data.String (IsString)
 
-import qualified Data.Text as T
+import qualified Data.Text   as T
 
 
 -- | A Makefile object, a list of makefile entries
@@ -44,7 +44,15 @@ data Makefile = Makefile { entries :: [Entry] } deriving (Show, Eq)
 -- variable assignment (@hello = world@ or @hello := world@)
 data Entry = Rule Target [Dependency] [Command]
            | Assignment AssignmentType T.Text T.Text
+           | Comment CommentType
            deriving (Show, Eq)
+
+data CommentType
+  = EmptyLine
+    -- ^ an empty line
+  | CommentText T.Text
+    -- ^ command text
+  deriving (Show, Eq)
 
 data AssignmentType
   = RecursiveAssign

--- a/src/Data/Makefile.hs
+++ b/src/Data/Makefile.hs
@@ -44,15 +44,9 @@ data Makefile = Makefile { entries :: [Entry] } deriving (Show, Eq)
 -- variable assignment (@hello = world@ or @hello := world@)
 data Entry = Rule Target [Dependency] [Command]
            | Assignment AssignmentType T.Text T.Text
-           | Comment CommentType
+           | Comment T.Text
+           | EmptyLine
            deriving (Show, Eq)
-
-data CommentType
-  = EmptyLine
-    -- ^ an empty line
-  | CommentText T.Text
-    -- ^ command text
-  deriving (Show, Eq)
 
 data AssignmentType
   = RecursiveAssign

--- a/src/Data/Makefile.hs
+++ b/src/Data/Makefile.hs
@@ -32,9 +32,9 @@ Makefile {
 
 module Data.Makefile where
 
-import           Data.String (IsString)
+import           Data.String                      (IsString)
 
-import qualified Data.Text   as T
+import qualified Data.Text as T
 
 
 -- | A Makefile object, a list of makefile entries

--- a/src/Data/Makefile/Render/Internal.hs
+++ b/src/Data/Makefile/Render/Internal.hs
@@ -3,9 +3,9 @@
 module Data.Makefile.Render.Internal where
 import           Data.Makefile
 import           Data.Monoid
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.IO as TL
-import Data.Text.Lazy.Builder
+import qualified Data.Text.Lazy         as TL
+import           Data.Text.Lazy.Builder
+import qualified Data.Text.Lazy.IO      as TL
 
 writeMakefile :: FilePath -> Makefile -> IO ()
 writeMakefile f m = do
@@ -36,6 +36,10 @@ renderEntry (Rule (Target t) ds cmds) =
   mconcat [singleton ' ' <> renderDep d | d <- ds] <>
   singleton '\n' <>
   mconcat [renderCmd cmd <> singleton '\n' | cmd <- cmds]
+renderEntry (Comment EmptyLine) =
+  fromText "#"
+renderEntry (Comment (CommentText text)) =
+  fromText "# " <> fromText text
 
 renderDep :: Dependency -> Builder
 renderDep (Dependency dep ) = fromText dep

--- a/src/Data/Makefile/Render/Internal.hs
+++ b/src/Data/Makefile/Render/Internal.hs
@@ -3,6 +3,7 @@
 module Data.Makefile.Render.Internal where
 import           Data.Makefile
 import           Data.Monoid
+import qualified Data.Text              as T
 import qualified Data.Text.Lazy         as TL
 import           Data.Text.Lazy.Builder
 import qualified Data.Text.Lazy.IO      as TL
@@ -36,10 +37,13 @@ renderEntry (Rule (Target t) ds cmds) =
   mconcat [singleton ' ' <> renderDep d | d <- ds] <>
   singleton '\n' <>
   mconcat [renderCmd cmd <> singleton '\n' | cmd <- cmds]
-renderEntry (Comment EmptyLine) =
-  fromText "#"
-renderEntry (Comment (CommentText text)) =
-  fromText "# " <> fromText text
+renderEntry EmptyLine =
+  fromText ""
+renderEntry (Comment text) =
+  let texts = map (\t -> fromText "# " <> fromText t ) $ T.lines text
+      con []     = mempty
+      con (x:xs) = foldl (\a b -> a <> fromText "\n" <> b) x xs
+  in con texts
 
 renderDep :: Dependency -> Builder
 renderDep (Dependency dep ) = fromText dep

--- a/src/Data/Makefile/Render/Internal.hs
+++ b/src/Data/Makefile/Render/Internal.hs
@@ -3,10 +3,10 @@
 module Data.Makefile.Render.Internal where
 import           Data.Makefile
 import           Data.Monoid
-import qualified Data.Text              as T
-import qualified Data.Text.Lazy         as TL
-import           Data.Text.Lazy.Builder
-import qualified Data.Text.Lazy.IO      as TL
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.IO as TL
+import Data.Text.Lazy.Builder
 
 writeMakefile :: FilePath -> Makefile -> IO ()
 writeMakefile f m = do


### PR DESCRIPTION
To add comment to Makefile, the `Comment` and `CommentType` are added.
When rendering from `Makefile` to `Text`, we can add comment for a Makefile.